### PR TITLE
Added exceptions catching

### DIFF
--- a/tasks/json_merge.js
+++ b/tasks/json_merge.js
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
           // Print a success message.
           grunt.log.writeln('File "' + f.dest + '" created.');
         } catch(e) {
-          grunt.log.error(e);
+          grunt.fail.warn(e);
         }
     });
   });

--- a/tasks/json_merge.js
+++ b/tasks/json_merge.js
@@ -42,16 +42,20 @@ module.exports = function(grunt) {
             return grunt.file.readJSON(filepath);
         });
         
-        var merged = _.deepExtend.apply(_,JSONS);
-        //_.extend.apply( _ , [merged].concat(JSONS) );
-        // Handle options.
-        
-    
-        // Write the destination file.
-        grunt.file.write(f.dest, JSON.stringify(merged, options.replacer, options.space) );
-    
-        // Print a success message.
-        grunt.log.writeln('File "' + f.dest + '" created.');
+        try {
+          var merged = _.deepExtend.apply(_,JSONS);
+          //_.extend.apply( _ , [merged].concat(JSONS) );
+          // Handle options.
+          
+      
+          // Write the destination file.
+          grunt.file.write(f.dest, JSON.stringify(merged, options.replacer, options.space) );
+      
+          // Print a success message.
+          grunt.log.writeln('File "' + f.dest + '" created.');
+        } catch(e) {
+          grunt.log.error(e);
+        }
     });
   });
 


### PR DESCRIPTION
Exceptions are sometimes thrown by _.deepExtend, and should be caught and reported, so the user will know the merging has failed.
